### PR TITLE
Accept new points with validation, add notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,19 @@ $ dotnet restore
 $ dotnet run
 ```
 in the /server folder.
+
+To add a new point to in memory storage, issue a HTTP request:
+```
+POST http://localhost:5000/api/points/7fdbd84a-2405-4c6c-8b12-e72c582e4b37
+content-type:application/json
+
+{
+    'id': '7fdbd84a-2405-4c6c-8b12-e72c582e4b37',
+    'tagId': 'testtag',
+    'date': '2016-12-19T21:07:31Z',
+    'int': 1337,
+    'dateTime': '2016-12-20T21:07:31Z',
+    'string': 'abacaba',
+    'float': 1337.0
+}
+```

--- a/notes/001-points-validation.md
+++ b/notes/001-points-validation.md
@@ -1,0 +1,30 @@
+The one with the tag config storage research and point schema validation
+===
+
+## Persistent storage facilities
+
+ASP.NET Core discourages having a state in a web app as it contradicts REST guidelines. The provided storage facilities are quite limited, here's the full list:
+* Per-request storage in HttpContext.Items
+* Per-session storage on client side: cookies, query string
+* Per-session storage on server side: distributed session cache in which the framework matches client's cookie with the cache instance and makes sure that the distributed part is handled properly, but developer must provide an external storage for backing the cache
+* Global read-only app config
+* Global in memory cache backed by an external storage
+* Raw global external storage
+
+For storing the tags configuration, only the three last options fit. Although, in the future we want to provide the api for the client to modify that config, so it's unreasonable to choose the read-only option now. We'll go for an external (file) storage with in memory caching. We'll stick with the same option for the points storage.
+
+## Validating mixed json models
+
+The main goal of our little project is to provide humans with an easy way to track arbitrary measurement points throughout the day. Point is transmitted as a json with two known fields (tag id and date) and a set of fields whose names and values are only known at runtime.
+
+There are several ways this kind of data structure can be represented in C#:
+* JObjects, with all validation coded by hand. This solution adds a lot of noise to the code and makes the type system highly dependent on a particular data type implementation from a third party library.
+* Dynamic objects, with the known fields validated in the code and unknown fields and types being checked via reflection. The only downside is the manual validation for the fields known at compile time.
+* DynamicObject descendants with known and unknown fields, where the unknown fields validation is handled through reflection. This approach has troubles with deserialization, as JSON.NET also uses reflection to set the values and ignores the helper methods for setting the unknown fields.
+* Ordinary class with two fields and a dictionary with a `JsonExtensionData` attribute. Validation for the known fields is handled by JSON deserializer, unknown fields are checked using reflection. This option seems to be the best candidate so far.
+
+ASP.NET Core encourages the developer to leave the model validation to the framework and only work with deserialized models in controller actions. To act on model validation issues, one either has to check the `ModelState` in the controller actions by hand or to define an action filter which can be reused across actions. ASP.NET Core provides a way to return all model validation error messages at once, but it doesn't work well with the kind of errors JSON.NET throws on missing fields, so for now our action filter will return an empty `BadRequestResult` if any issues are encountered. This can be improved by overriding the serializer of JSON.NET exceptions, which on the other hand increases code complexity and may cause sensitive data leakage, so such decision is to be taken carefully.
+
+## Type checking
+
+For our purposes, only a handful of types is needed for the point fields: string, int, double, date, time and custom enums. Sounds simple, but there's a catch: there's no standartized date format in JSON, so by convention dates are usually passed as strings in ISO 8601 format. Moreover, the Point objects are required to contain a calendar date, and there is no standardized way to encode a date without time or time of a day, and that forces us to come up with our own conventions. C# type system doesn't have the date separation as well, so even with the aid of reflection a custom type description and validation system is needed. As a good starting point, we'll stick to the C# type checks and introduce the custom types later on.

--- a/server/Controllers/HelloController.cs
+++ b/server/Controllers/HelloController.cs
@@ -8,9 +8,9 @@ namespace hutel.Controllers
     {
         // GET api/hello
         [HttpGet]
-        public IDictionary<string, string> Get()
+        public IActionResult Get()
         {
-            return new Dictionary<string, string> { { "hello", "world" } };
+            return Json(new Dictionary<string, string> { { "hello", "world" } });
         }
     }
 }

--- a/server/Controllers/HelloController.cs
+++ b/server/Controllers/HelloController.cs
@@ -1,15 +1,12 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
- 
+
 namespace hutel.Controllers
 {
     [Route("api/[controller]")]
     public class HelloController : Controller
     {
-        // GET api/values
+        // GET api/hello
         [HttpGet]
         public IDictionary<string, string> Get()
         {

--- a/server/Controllers/PointsController.cs
+++ b/server/Controllers/PointsController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using hutel.Filters;
+using hutel.Logic;
 using hutel.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
@@ -46,7 +47,18 @@ namespace hutel.Controllers
         {
             var points = _memoryCache.Get<Dictionary<Guid, Point>>(_pointsKey);
             var tags = _memoryCache.Get<Dictionary<string, Tag>>(_tagsKey);
-            tags[point.TagId].Validate(point);
+            try
+            {
+                if (!tags.ContainsKey(point.TagId))
+                {
+                    throw new ValidationException($"Unknown tag: {point.TagId}");
+                }
+                PointValidator.Validate(point, tags[point.TagId]);
+            }
+            catch(ValidationException ex)
+            {
+                return new BadRequestObjectResult(ex.ToString());
+            }
             points[id] = point;
             return Json(points);
         }

--- a/server/Controllers/PointsController.cs
+++ b/server/Controllers/PointsController.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using hutel.Filters;
+using hutel.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace hutel.Controllers
+{
+    [Route("api/[controller]")]
+    public class PointsController : Controller
+    {
+        private IMemoryCache _memoryCache;
+        private const string _pointsKey = "points";
+        private const string _tagsKey = "tags";
+
+        public PointsController(IMemoryCache memoryCache)
+        {
+            _memoryCache = memoryCache;
+            Dictionary<Guid, Point> points;
+            if (!_memoryCache.TryGetValue(_pointsKey, out points))
+            {
+                _memoryCache.Set(
+                    _pointsKey,
+                    new Dictionary<Guid, Point>(),
+                    new MemoryCacheEntryOptions()
+                        .SetPriority(CacheItemPriority.NeverRemove)
+                );
+            }
+            Dictionary<string, Tag> tags;
+            if (!memoryCache.TryGetValue(_tagsKey, out tags))
+            {
+                _memoryCache.Set(
+                    _tagsKey,
+                    CreateTags(),
+                    new MemoryCacheEntryOptions()
+                        .SetPriority(CacheItemPriority.NeverRemove)
+                );
+            }
+        }
+
+        // POST api/points/id
+        [HttpPost("{id}")]
+        [ValidateModelState]
+        public IActionResult Post(Guid id, [FromBody]Point point)
+        {
+            var points = _memoryCache.Get<Dictionary<Guid, Point>>(_pointsKey);
+            var tags = _memoryCache.Get<Dictionary<string, Tag>>(_tagsKey);
+            tags[point.TagId].Validate(point);
+            points[id] = point;
+            return Json(points);
+        }
+
+        private static Dictionary<string, Tag> CreateTags()
+        {
+            return new Dictionary<string, Tag>
+            {
+                {
+                    "testtag",
+                    new Tag
+                    {
+                        Id = "testtag",
+                        Fields = new Dictionary<string, Tag.Field>
+                        {
+                            {
+                                "int",
+                                new Tag.Field
+                                {
+                                    Name = "int",
+                                    Type = Type.GetType("System.Int64")
+                                }
+                            },
+                            {
+                                "dateTime",
+                                new Tag.Field
+                                {
+                                    Name = "dateTime",
+                                    Type = Type.GetType("System.DateTime")
+                                }
+                            },
+                            {
+                                "string",
+                                new Tag.Field
+                                {
+                                    Name = "string",
+                                    Type = Type.GetType("System.String")
+                                }
+                            },
+                            {
+                                "float",
+                                new Tag.Field
+                                {
+                                    Name = "float",
+                                    Type = Type.GetType("System.Double")
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/server/Filters/ValidateModelStateFilter.cs
+++ b/server/Filters/ValidateModelStateFilter.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace hutel.Filters
+{
+    public class ValidateModelStateAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext actionContext)
+        {
+            if (actionContext.ModelState.IsValid == false)
+            {
+                actionContext.Result = new BadRequestResult();
+            }
+        }
+    }
+}

--- a/server/Logic/PointValidator.cs
+++ b/server/Logic/PointValidator.cs
@@ -1,0 +1,56 @@
+using System;
+using hutel.Models;
+
+namespace hutel.Logic
+{
+    public class PointValidator
+    {
+        public static void Validate(Point point, Tag tag)
+        {
+            if (tag == null)
+            {
+                throw new ValidationException($"Unknown tag: {point.TagId}");
+            }
+            if (point.TagId != tag.Id)
+            {
+                throw new ValidationException($"Tag id mismatch: expected {tag.Id}, got {point.TagId}");
+            }
+            
+            foreach (var pointField in point.Extra.Keys)
+            {
+                if (!tag.Fields.ContainsKey(pointField))
+                {
+                    throw new ValidationException($"Unknown property: {pointField}");
+                }
+            }
+            foreach (var tagField in tag.Fields.Values)
+            {
+                if (!point.Extra.ContainsKey(tagField.Name))
+                {
+                    throw new ValidationException($"Property not found: {tagField.Name}");
+                }
+                var pointFieldType = point.Extra[tagField.Name].GetType();
+                if (pointFieldType != tagField.Type)
+                {
+                    throw new ValidationException(
+                        $"Type mismatch for property {tagField.Name}: " +
+                        $"expected {tagField.Type}, got {pointFieldType}");
+                }
+            }
+        }
+    }
+    public class ValidationException: Exception
+    {
+        public ValidationException()
+        {
+        }
+
+        public ValidationException(string message): base(message)
+        {
+        }
+
+        public ValidationException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/server/Models/Point.cs
+++ b/server/Models/Point.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace hutel.Models
+{
+    public class Point
+    {
+        [JsonProperty(Required = Required.Always)]
+        public Guid Id { get; set; }
+        
+        [JsonProperty(Required = Required.Always)]
+        public string TagId { get; set; }
+        
+        [JsonProperty(Required = Required.Always)]
+        public DateTime Date { get; set; }
+
+        [JsonExtensionData]
+        public Dictionary<string, object> Extra { get; set; }
+    }
+}

--- a/server/Models/Tag.cs
+++ b/server/Models/Tag.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace hutel.Models
 {
@@ -16,51 +15,6 @@ namespace hutel.Models
 
             public Type Type { get; set; }
 
-        }
-
-        public class ValidationException: Exception
-        {
-            public ValidationException()
-            {
-            }
-
-            public ValidationException(string message): base(message)
-            {
-            }
-
-            public ValidationException(string message, Exception inner) : base(message, inner)
-            {
-            }
-        }
-
-        public void Validate(Point point)
-        {
-            if (point.TagId != this.Id)
-            {
-                throw new ValidationException($"Tag id mismatch: expected {this.Id}, got {point.TagId}");
-            }
-            
-            foreach (var pointField in point.Extra.Keys)
-            {
-                if (!this.Fields.ContainsKey(pointField))
-                {
-                    throw new ValidationException($"Unknown property: {pointField}");
-                }
-            }
-            foreach (var tagField in this.Fields.Values)
-            {
-                if (!point.Extra.ContainsKey(tagField.Name))
-                {
-                    throw new ValidationException($"Property not found: {tagField.Name}");
-                }
-                var pointFieldType = point.Extra[tagField.Name].GetType();
-                if (pointFieldType != tagField.Type)
-                {
-                    throw new ValidationException(
-                        $"Type mismatch for property {tagField.Name}: " +
-                        $"expected {tagField.Type}, got {pointFieldType}");
-                }
-            }
         }
     }
 }

--- a/server/Models/Tag.cs
+++ b/server/Models/Tag.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace hutel.Models
+{
+    public class Tag
+    {
+        public string Id { get; set; }
+
+        public IDictionary<string, Field> Fields { get; set; }
+
+        public class Field
+        {
+            public string Name { get; set; }
+
+            public Type Type { get; set; }
+
+        }
+
+        public class ValidationException: Exception
+        {
+            public ValidationException()
+            {
+            }
+
+            public ValidationException(string message): base(message)
+            {
+            }
+
+            public ValidationException(string message, Exception inner) : base(message, inner)
+            {
+            }
+        }
+
+        public void Validate(Point point)
+        {
+            if (point.TagId != this.Id)
+            {
+                throw new ValidationException($"Tag id mismatch: expected {this.Id}, got {point.TagId}");
+            }
+            
+            foreach (var pointField in point.Extra.Keys)
+            {
+                if (!this.Fields.ContainsKey(pointField))
+                {
+                    throw new ValidationException($"Unknown property: {pointField}");
+                }
+            }
+            foreach (var tagField in this.Fields.Values)
+            {
+                if (!point.Extra.ContainsKey(tagField.Name))
+                {
+                    throw new ValidationException($"Property not found: {tagField.Name}");
+                }
+                var pointFieldType = point.Extra[tagField.Name].GetType();
+                if (pointFieldType != tagField.Type)
+                {
+                    throw new ValidationException(
+                        $"Type mismatch for property {tagField.Name}: " +
+                        $"expected {tagField.Type}, got {pointFieldType}");
+                }
+            }
+        }
+    }
+}

--- a/server/Startup.cs
+++ b/server/Startup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using hutel.Filters;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -17,18 +18,20 @@ namespace server
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc();
+            services.AddScoped<ValidateModelStateAttribute>();
+            services.AddMemoryCache();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
-            loggerFactory.AddConsole();
+            loggerFactory.AddConsole(LogLevel.Trace);
 
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
-             
+            
             app.UseMvc();
         }
     }

--- a/server/project.json
+++ b/server/project.json
@@ -9,6 +9,7 @@
     "Microsoft.AspNetCore.Server.IISIntegration": "1.1.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.1.0",
     "Microsoft.Extensions.Logging.Console": "1.1.0",
+    "Microsoft.Extensions.Caching.Memory": "1.1.0",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.1.0",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.1.0",
     "Microsoft.Extensions.Configuration.Json": "1.1.0",
@@ -26,7 +27,8 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true
+    "preserveCompilationContext": true,
+    "debugType": "portable"
   },
 
   "runtimeOptions": {


### PR DESCRIPTION
Added validation of incoming points against a hardcoded tag definition. Field types are declared as C# types, validation is done through reflection. As described in notes, C# types are not a good fit for this project, so the task was added to implement a custom type system.
Added in-memory storage for the points. Thread safety is currently an issue, but it's good enough for sending requests manually.
Added notes on all learnings.
Switched the debug info type to portable to be able to debug with VS Code.